### PR TITLE
Add Android Auto media support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,9 @@
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaSessionService" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.media.browse.MediaBrowserService" />
+            </intent-filter>
         </service>
 
         <service
@@ -60,6 +63,10 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
             android:value="fcm_default" />
+
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
 
     </application>
 

--- a/app/src/main/java/net/afanasev/otonfm/data/status/StatusModel.kt
+++ b/app/src/main/java/net/afanasev/otonfm/data/status/StatusModel.kt
@@ -4,8 +4,6 @@ import android.annotation.SuppressLint
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-const val STATION_NAME = "Oton FM"
-const val STATION_STREAM_URL = "https://s4.radio.co/s696f24a77/listen"
 const val DEFAULT_ARTWORK_URI =
     "https://images.radio.co/station_logos/s696f24a77.20250505065303.jpg"
 

--- a/app/src/main/java/net/afanasev/otonfm/data/status/StatusModel.kt
+++ b/app/src/main/java/net/afanasev/otonfm/data/status/StatusModel.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+const val STATION_NAME = "Oton FM"
+const val STATION_STREAM_URL = "https://s4.radio.co/s696f24a77/listen"
 const val DEFAULT_ARTWORK_URI =
     "https://images.radio.co/station_logos/s696f24a77.20250505065303.jpg"
 

--- a/app/src/main/java/net/afanasev/otonfm/data/status/StatusModel.kt
+++ b/app/src/main/java/net/afanasev/otonfm/data/status/StatusModel.kt
@@ -4,9 +4,6 @@ import android.annotation.SuppressLint
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-const val DEFAULT_ARTWORK_URI =
-    "https://images.radio.co/station_logos/s696f24a77.20250505065303.jpg"
-
 @SuppressLint("UnsafeOptInUsageError")
 @Serializable
 internal data class StatusModel(

--- a/app/src/main/java/net/afanasev/otonfm/data/status/StatusRepository.kt
+++ b/app/src/main/java/net/afanasev/otonfm/data/status/StatusRepository.kt
@@ -33,18 +33,18 @@ class StatusRepository {
         }
     }
 
-    suspend fun fetchArtworkUri(expectedTitle: String): String {
+    suspend fun fetchArtworkUri(expectedTitle: String): String? {
         repeat(RETRY_MAX_COUNT) { attemptIdx ->
             loadStatus()?.let {
                 if (it.currentTrack.title == expectedTitle) {
-                    return it.currentTrack.artworkUri ?: DEFAULT_ARTWORK_URI
+                    return it.currentTrack.artworkUri
                 }
             }
             Logger.logArtworkMismatch(attemptIdx + 1, RETRY_MAX_COUNT, RETRY_DELAY_MS)
             delay(RETRY_DELAY_MS)
         }
 
-        return DEFAULT_ARTWORK_URI
+        return null
     }
 
     private suspend fun loadStatus(): StatusModel? {

--- a/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
+++ b/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.launch
 import net.afanasev.otonfm.MainActivity
 import net.afanasev.otonfm.OtonFmApplication
 import net.afanasev.otonfm.R
-import net.afanasev.otonfm.data.status.DEFAULT_ARTWORK_URI
 
 private const val ROOT_ID = "root"
 private const val STATION_ID = "oton_fm_station"
@@ -62,7 +61,7 @@ class PlaybackService : MediaLibraryService() {
             val root = MediaItem.Builder()
                 .setMediaId(ROOT_ID)
                 .setMediaMetadata(
-                    androidx.media3.common.MediaMetadata.Builder()
+                    MediaMetadata.Builder()
                         .setIsBrowsable(true)
                         .setIsPlayable(false)
                         .build()
@@ -88,9 +87,9 @@ class PlaybackService : MediaLibraryService() {
                 .setMediaId(STATION_ID)
                 .setUri(getString(R.string.stream_url))
                 .setMediaMetadata(
-                    androidx.media3.common.MediaMetadata.Builder()
+                    MediaMetadata.Builder()
                         .setTitle(getString(R.string.app_name))
-                        .setArtworkUri(DEFAULT_ARTWORK_URI.toUri())
+                        .setArtworkUri(getString(R.string.default_artwork_uri).toUri())
                         .setIsBrowsable(false)
                         .setIsPlayable(true)
                         .build()
@@ -148,6 +147,7 @@ class PlaybackService : MediaLibraryService() {
                 artworkJob?.cancel()
                 artworkJob = serviceScope.launch {
                     val uri = (application as OtonFmApplication).statusRepository.fetchArtworkUri(title)
+                        ?: getString(R.string.default_artwork_uri)
                     val currentItem = player.currentMediaItem ?: return@launch
                     val updatedMetadata = currentItem.mediaMetadata.buildUpon()
                         .setArtworkUri(uri.toUri())

--- a/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
+++ b/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
@@ -28,6 +28,8 @@ import kotlinx.coroutines.launch
 import net.afanasev.otonfm.MainActivity
 import net.afanasev.otonfm.OtonFmApplication
 import net.afanasev.otonfm.data.status.DEFAULT_ARTWORK_URI
+import net.afanasev.otonfm.data.status.STATION_NAME
+import net.afanasev.otonfm.data.status.STATION_STREAM_URL
 
 private const val ROOT_ID = "root"
 private const val STATION_ID = "oton_fm_station"
@@ -85,10 +87,10 @@ class PlaybackService : MediaLibraryService() {
             }
             val stationItem = MediaItem.Builder()
                 .setMediaId(STATION_ID)
-                .setUri("https://s4.radio.co/s696f24a77/listen")
+                .setUri(STATION_STREAM_URL)
                 .setMediaMetadata(
                     androidx.media3.common.MediaMetadata.Builder()
-                        .setTitle("Oton FM")
+                        .setTitle(STATION_NAME)
                         .setArtworkUri(DEFAULT_ARTWORK_URI.toUri())
                         .setIsBrowsable(false)
                         .setIsPlayable(true)

--- a/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
+++ b/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
@@ -27,9 +27,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import net.afanasev.otonfm.MainActivity
 import net.afanasev.otonfm.OtonFmApplication
+import net.afanasev.otonfm.R
 import net.afanasev.otonfm.data.status.DEFAULT_ARTWORK_URI
-import net.afanasev.otonfm.data.status.STATION_NAME
-import net.afanasev.otonfm.data.status.STATION_STREAM_URL
 
 private const val ROOT_ID = "root"
 private const val STATION_ID = "oton_fm_station"
@@ -87,10 +86,10 @@ class PlaybackService : MediaLibraryService() {
             }
             val stationItem = MediaItem.Builder()
                 .setMediaId(STATION_ID)
-                .setUri(STATION_STREAM_URL)
+                .setUri(getString(R.string.stream_url))
                 .setMediaMetadata(
                     androidx.media3.common.MediaMetadata.Builder()
-                        .setTitle(STATION_NAME)
+                        .setTitle(getString(R.string.app_name))
                         .setArtworkUri(DEFAULT_ARTWORK_URI.toUri())
                         .setIsBrowsable(false)
                         .setIsPlayable(true)

--- a/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
+++ b/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
@@ -9,11 +9,16 @@ import android.media.AudioManager
 import androidx.core.net.toUri
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.LibraryResult
+import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
-import androidx.media3.session.MediaSessionService
+import com.google.common.collect.ImmutableList
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -22,10 +27,14 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import net.afanasev.otonfm.MainActivity
 import net.afanasev.otonfm.OtonFmApplication
+import net.afanasev.otonfm.data.status.DEFAULT_ARTWORK_URI
 
-class PlaybackService : MediaSessionService() {
+private const val ROOT_ID = "root"
+private const val STATION_ID = "oton_fm_station"
 
-    private var mediaSession: MediaSession? = null
+class PlaybackService : MediaLibraryService() {
+
+    private var mediaLibrarySession: MediaLibrarySession? = null
     private var artworkJob: Job? = null
     private var lastFetchedTitle: String? = null
 
@@ -34,18 +43,64 @@ class PlaybackService : MediaSessionService() {
         override fun onReceive(context: Context, intent: Intent) {
             // stop playing music when become noisy (e.g. unplug headphones)
             if (intent.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
-                mediaSession?.let {
+                mediaLibrarySession?.let {
                     if (it.player.isPlaying) {
                         it.player.stop()
                     }
                 }
             }
         }
-
     }
 
-    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? =
-        mediaSession
+    private val libraryCallback = object : MediaLibrarySession.Callback {
+        override fun onGetLibraryRoot(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            params: LibraryParams?,
+        ): ListenableFuture<LibraryResult<MediaItem>> {
+            val root = MediaItem.Builder()
+                .setMediaId(ROOT_ID)
+                .setMediaMetadata(
+                    androidx.media3.common.MediaMetadata.Builder()
+                        .setIsBrowsable(true)
+                        .setIsPlayable(false)
+                        .build()
+                )
+                .build()
+            return Futures.immediateFuture(LibraryResult.ofItem(root, params))
+        }
+
+        override fun onGetChildren(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            parentId: String,
+            page: Int,
+            pageSize: Int,
+            params: LibraryParams?,
+        ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
+            if (parentId != ROOT_ID) {
+                return Futures.immediateFuture(
+                    LibraryResult.ofError(LibraryResult.RESULT_ERROR_BAD_VALUE)
+                )
+            }
+            val stationItem = MediaItem.Builder()
+                .setMediaId(STATION_ID)
+                .setUri("https://s4.radio.co/s696f24a77/listen")
+                .setMediaMetadata(
+                    androidx.media3.common.MediaMetadata.Builder()
+                        .setTitle("Oton FM")
+                        .setArtworkUri(DEFAULT_ARTWORK_URI.toUri())
+                        .setIsBrowsable(false)
+                        .setIsPlayable(true)
+                        .build()
+                )
+                .build()
+            return Futures.immediateFuture(LibraryResult.ofItemList(ImmutableList.of(stationItem), params))
+        }
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? =
+        mediaLibrarySession
 
     override fun onCreate() {
         super.onCreate()
@@ -54,7 +109,7 @@ class PlaybackService : MediaSessionService() {
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        val player = mediaSession?.player ?: return
+        val player = mediaLibrarySession?.player ?: return
         if (!player.playWhenReady || player.mediaItemCount == 0) {
             stopSelf()
         }
@@ -111,7 +166,7 @@ class PlaybackService : MediaSessionService() {
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 
-        mediaSession = MediaSession.Builder(this, player)
+        mediaLibrarySession = MediaLibrarySession.Builder(this, player, libraryCallback)
             .setSessionActivity(sessionActivity)
             .build()
     }
@@ -119,10 +174,10 @@ class PlaybackService : MediaSessionService() {
     private fun destroyMediaSession() {
         artworkJob?.cancel()
         serviceScope.cancel()
-        mediaSession?.let {
+        mediaLibrarySession?.let {
             it.player.release()
             it.release()
-            mediaSession = null
+            mediaLibrarySession = null
         }
     }
 }

--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/player/PlayerViewModel.kt
@@ -20,6 +20,7 @@ import net.afanasev.otonfm.OtonFmApplication
 import net.afanasev.otonfm.data.adminstatus.AdminStatusRepository
 import net.afanasev.otonfm.data.adminstatus.AdminStatusModel
 import net.afanasev.otonfm.data.status.DEFAULT_ARTWORK_URI
+import net.afanasev.otonfm.data.status.STATION_STREAM_URL
 import net.afanasev.otonfm.services.PlaybackService
 
 class PlayerViewModel(application: Application) : AndroidViewModel(application) {
@@ -83,7 +84,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
             if (it.isPlaying) {
                 it.pause()
             } else {
-                val mediaItem = MediaItem.fromUri("https://s4.radio.co/s696f24a77/listen")
+                val mediaItem = MediaItem.fromUri(STATION_STREAM_URL)
                 it.setMediaItem(mediaItem)
                 it.prepare()
                 it.play()

--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/player/PlayerViewModel.kt
@@ -20,7 +20,6 @@ import net.afanasev.otonfm.OtonFmApplication
 import net.afanasev.otonfm.data.adminstatus.AdminStatusRepository
 import net.afanasev.otonfm.data.adminstatus.AdminStatusModel
 import net.afanasev.otonfm.R
-import net.afanasev.otonfm.data.status.DEFAULT_ARTWORK_URI
 import net.afanasev.otonfm.services.PlaybackService
 
 class PlayerViewModel(application: Application) : AndroidViewModel(application) {
@@ -28,7 +27,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
     private val _adminStatus = MutableStateFlow<AdminStatusModel?>(AdminStatusModel())
     val adminStatus: StateFlow<AdminStatusModel?> = _adminStatus.asStateFlow()
 
-    private val _artworkUri = MutableStateFlow<String>(DEFAULT_ARTWORK_URI)
+    private val _artworkUri = MutableStateFlow<String>(getApplication<Application>().getString(R.string.default_artwork_uri))
     val artworkUri: StateFlow<String> = _artworkUri.asStateFlow()
 
     private val _title = MutableStateFlow("")
@@ -94,7 +93,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
 
     private fun setMetadata(mediaMetadata: MediaMetadata) {
         _title.value = mediaMetadata.title?.toString() ?: ""
-        _artworkUri.value = mediaMetadata.artworkUri?.toString() ?: DEFAULT_ARTWORK_URI
+        _artworkUri.value = mediaMetadata.artworkUri?.toString() ?: getApplication<Application>().getString(R.string.default_artwork_uri)
 
         viewModelScope.launch {
             _nextTrackTitle.value = statusRepository.fetchNextTrack().orEmpty()

--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/player/PlayerViewModel.kt
@@ -19,8 +19,8 @@ import kotlinx.coroutines.launch
 import net.afanasev.otonfm.OtonFmApplication
 import net.afanasev.otonfm.data.adminstatus.AdminStatusRepository
 import net.afanasev.otonfm.data.adminstatus.AdminStatusModel
+import net.afanasev.otonfm.R
 import net.afanasev.otonfm.data.status.DEFAULT_ARTWORK_URI
-import net.afanasev.otonfm.data.status.STATION_STREAM_URL
 import net.afanasev.otonfm.services.PlaybackService
 
 class PlayerViewModel(application: Application) : AndroidViewModel(application) {
@@ -84,7 +84,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
             if (it.isPlaying) {
                 it.pause()
             } else {
-                val mediaItem = MediaItem.fromUri(STATION_STREAM_URL)
+                val mediaItem = MediaItem.fromUri(getApplication<Application>().getString(R.string.stream_url))
                 it.setMediaItem(mediaItem)
                 it.prepare()
                 it.play()

--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/Artwork.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/Artwork.kt
@@ -13,12 +13,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
-import net.afanasev.otonfm.data.status.DEFAULT_ARTWORK_URI
+import net.afanasev.otonfm.R
 import net.afanasev.otonfm.ui.theme.LocalCustomColorsPalette
 
 @Composable
@@ -58,7 +59,7 @@ fun Artwork(
 @Composable
 fun ArtworkNoImagePreview() {
     Artwork(
-        artworkUri = DEFAULT_ARTWORK_URI,
+        artworkUri = stringResource(R.string.default_artwork_uri),
         modifier = Modifier.width(60.dp),
     )
 }

--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/Background.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/Background.kt
@@ -19,12 +19,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import kotlinx.coroutines.delay
-import net.afanasev.otonfm.data.status.DEFAULT_ARTWORK_URI
+import net.afanasev.otonfm.R
 import net.afanasev.otonfm.ui.theme.BACKGROUND_GRADIENTS
 import kotlin.random.Random
 
@@ -34,7 +35,7 @@ fun Background(
     modifier: Modifier,
 ) {
     Crossfade(
-        targetState = artworkUri == DEFAULT_ARTWORK_URI,
+        targetState = artworkUri == stringResource(R.string.default_artwork_uri),
         animationSpec = tween(1_000),
     ) { showGradient ->
         if (showGradient) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name" translatable="false">Oton.FM</string>
     <string name="stream_url" translatable="false">https://s4.radio.co/s696f24a77/listen</string>
+    <string name="default_artwork_uri" translatable="false">https://images.radio.co/station_logos/s696f24a77.20250505065303.jpg</string>
 
     <string name="menu_theme">Оформление</string>
     <string name="menu_contacts">Контакты</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name" translatable="false">Oton.FM</string>
+    <string name="stream_url" translatable="false">https://s4.radio.co/s696f24a77/listen</string>
 
     <string name="menu_theme">Оформление</string>
     <string name="menu_contacts">Контакты</string>

--- a/app/src/main/res/xml/automotive_app_desc.xml
+++ b/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+    <uses name="media"/>
+</automotiveApp>


### PR DESCRIPTION
## Summary
- Add Android Auto media browser support via `MediaLibraryService`, exposing the station as a browsable/playable media item
- Fetch and update track artwork asynchronously using `StatusRepository`, retrying up to 3 times on title mismatch
- Move `DEFAULT_ARTWORK_URI` and stream URL out of Kotlin constants into non-translatable string resources, keeping the data layer free of Android resource references
- `StatusRepository.fetchArtworkUri` returns `String?` (null = no artwork found); each caller resolves the fallback via `getString` / `stringResource`

## Test plan
- [ ] Launch app — station plays normally, artwork loads for current track
- [ ] Default station logo displays when no track artwork is available
- [ ] Connect Android Auto (or use Desktop Head Unit emulator) — station appears in media browser and is playable
- [ ] Unplug headphones while playing — playback stops (noisy receiver working)
- [ ] Build passes with no compile errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)