### PR TITLE
Add gyroscope parallax effect to artwork

### DIFF
--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/Artwork.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/Artwork.kt
@@ -1,5 +1,15 @@
 package net.afanasev.otonfm.ui.screens.player.components
 
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.Handler
+import android.os.Looper
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
@@ -7,12 +17,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -28,9 +45,16 @@ fun Artwork(
     modifier: Modifier,
 ) {
     val previewShape = RoundedCornerShape(12.dp)
+    val density = LocalDensity.current
+    val (offsetXDp, offsetYDp) = rememberParallaxOffset()
+
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
+            .graphicsLayer {
+                translationX = with(density) { offsetXDp.dp.toPx() }
+                translationY = with(density) { offsetYDp.dp.toPx() }
+            }
             .then(
                 Modifier
                     .aspectRatio(1f)
@@ -53,6 +77,67 @@ fun Artwork(
             modifier = Modifier.fillMaxSize(),
         )
     }
+}
+
+@Composable
+private fun rememberParallaxOffset(maxOffsetDp: Float = 18f): Pair<Float, Float> {
+    val context = LocalContext.current
+    val sensorManager = remember {
+        context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    }
+    val sensor = remember {
+        sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
+    }
+
+    var rawRoll by remember { mutableFloatStateOf(0f) }
+    var rawPitch by remember { mutableFloatStateOf(0f) }
+    val baseline = remember { floatArrayOf(Float.NaN, Float.NaN) }
+
+    DisposableEffect(sensor) {
+        if (sensor == null) return@DisposableEffect onDispose {}
+
+        val rotationMatrix = FloatArray(9)
+        val orientation = FloatArray(3)
+        val scale = maxOffsetDp / 0.3f
+
+        val listener = object : SensorEventListener {
+            override fun onAccuracyChanged(s: Sensor, accuracy: Int) = Unit
+            override fun onSensorChanged(event: SensorEvent) {
+                SensorManager.getRotationMatrixFromVector(rotationMatrix, event.values)
+                SensorManager.getOrientation(rotationMatrix, orientation)
+                val pitch = orientation[1]
+                val roll = orientation[2]
+                if (baseline[0].isNaN()) {
+                    baseline[0] = pitch
+                    baseline[1] = roll
+                }
+                rawRoll = (roll - baseline[1]).coerceIn(-0.3f, 0.3f) * scale
+                rawPitch = (pitch - baseline[0]).coerceIn(-0.3f, 0.3f) * scale
+            }
+        }
+
+        sensorManager.registerListener(
+            listener,
+            sensor,
+            SensorManager.SENSOR_DELAY_GAME,
+            Handler(Looper.getMainLooper()),
+        )
+
+        onDispose { sensorManager.unregisterListener(listener) }
+    }
+
+    val smoothX by animateFloatAsState(
+        targetValue = rawRoll,
+        animationSpec = spring(Spring.DampingRatioMediumBouncy, Spring.StiffnessLow),
+        label = "parallaxX",
+    )
+    val smoothY by animateFloatAsState(
+        targetValue = rawPitch,
+        animationSpec = spring(Spring.DampingRatioMediumBouncy, Spring.StiffnessLow),
+        label = "parallaxY",
+    )
+
+    return Pair(smoothX, smoothY)
 }
 
 @Preview

--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/Artwork.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/Artwork.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -45,15 +44,15 @@ fun Artwork(
     modifier: Modifier,
 ) {
     val previewShape = RoundedCornerShape(12.dp)
-    val density = LocalDensity.current
-    val (offsetXDp, offsetYDp) = rememberParallaxOffset()
+    val (rotX, rotY) = rememberParallaxRotation()
 
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .graphicsLayer {
-                translationX = with(density) { offsetXDp.dp.toPx() }
-                translationY = with(density) { offsetYDp.dp.toPx() }
+                rotationX = rotX
+                rotationY = rotY
+                cameraDistance = 12f * density
             }
             .then(
                 Modifier
@@ -80,7 +79,7 @@ fun Artwork(
 }
 
 @Composable
-private fun rememberParallaxOffset(maxOffsetDp: Float = 18f): Pair<Float, Float> {
+private fun rememberParallaxRotation(maxDegrees: Float = 15f): Pair<Float, Float> {
     val context = LocalContext.current
     val sensorManager = remember {
         context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
@@ -89,8 +88,8 @@ private fun rememberParallaxOffset(maxOffsetDp: Float = 18f): Pair<Float, Float>
         sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
     }
 
-    var rawRoll by remember { mutableFloatStateOf(0f) }
-    var rawPitch by remember { mutableFloatStateOf(0f) }
+    var rawRotX by remember { mutableFloatStateOf(0f) }
+    var rawRotY by remember { mutableFloatStateOf(0f) }
     val baseline = remember { floatArrayOf(Float.NaN, Float.NaN) }
 
     DisposableEffect(sensor) {
@@ -98,7 +97,7 @@ private fun rememberParallaxOffset(maxOffsetDp: Float = 18f): Pair<Float, Float>
 
         val rotationMatrix = FloatArray(9)
         val orientation = FloatArray(3)
-        val scale = maxOffsetDp / 0.3f
+        val maxRadians = Math.toRadians(maxDegrees.toDouble()).toFloat()
 
         val listener = object : SensorEventListener {
             override fun onAccuracyChanged(s: Sensor, accuracy: Int) = Unit
@@ -111,8 +110,10 @@ private fun rememberParallaxOffset(maxOffsetDp: Float = 18f): Pair<Float, Float>
                     baseline[0] = pitch
                     baseline[1] = roll
                 }
-                rawRoll = (roll - baseline[1]).coerceIn(-0.3f, 0.3f) * scale
-                rawPitch = (pitch - baseline[0]).coerceIn(-0.3f, 0.3f) * scale
+                val deltaPitch = (pitch - baseline[0]).coerceIn(-maxRadians, maxRadians)
+                val deltaRoll = (roll - baseline[1]).coerceIn(-maxRadians, maxRadians)
+                rawRotX = Math.toDegrees(deltaPitch.toDouble()).toFloat()
+                rawRotY = -Math.toDegrees(deltaRoll.toDouble()).toFloat()
             }
         }
 
@@ -126,18 +127,18 @@ private fun rememberParallaxOffset(maxOffsetDp: Float = 18f): Pair<Float, Float>
         onDispose { sensorManager.unregisterListener(listener) }
     }
 
-    val smoothX by animateFloatAsState(
-        targetValue = rawRoll,
+    val smoothRotX by animateFloatAsState(
+        targetValue = rawRotX,
         animationSpec = spring(Spring.DampingRatioMediumBouncy, Spring.StiffnessLow),
-        label = "parallaxX",
+        label = "parallaxRotX",
     )
-    val smoothY by animateFloatAsState(
-        targetValue = rawPitch,
+    val smoothRotY by animateFloatAsState(
+        targetValue = rawRotY,
         animationSpec = spring(Spring.DampingRatioMediumBouncy, Spring.StiffnessLow),
-        label = "parallaxY",
+        label = "parallaxRotY",
     )
 
-    return Pair(smoothX, smoothY)
+    return Pair(smoothRotX, smoothRotY)
 }
 
 @Preview

--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/Artwork.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/Artwork.kt
@@ -79,7 +79,7 @@ fun Artwork(
 }
 
 @Composable
-private fun rememberParallaxRotation(maxDegrees: Float = 15f): Pair<Float, Float> {
+private fun rememberParallaxRotation(maxDegrees: Float = 4f): Pair<Float, Float> {
     val context = LocalContext.current
     val sensorManager = remember {
         context.getSystemService(Context.SENSOR_SERVICE) as SensorManager


### PR DESCRIPTION
## Summary

- Adds a subtle 3D parallax effect to the album artwork on the player screen: tilting the phone rotates the artwork in perspective, like a card viewed from different angles
- Uses \`TYPE_ROTATION_VECTOR\` (fused sensor — gyro + accelerometer) for smooth, drift-free orientation data
- Effect is delta-based, relative to however the user is holding the phone when the screen loads
- Smoothed with a \`spring\` animation (\`DampingRatioMediumBouncy\` / \`StiffnessLow\`) for a natural lag-and-catch-up feel
- Applied via \`graphicsLayer { rotationX/Y }\` — the artwork stays fixed in position and tilts in 3D perspective; \`cameraDistance\` is set explicitly for a natural depth feel
- Max tilt is ±4° for a subtle, non-distracting effect
- Sensor listener registered/unregistered with the composable lifecycle via \`DisposableEffect\`; falls back gracefully (no tilt) when the sensor is unavailable (emulator, preview)

## Implementation notes

- All changes are in \`Artwork.kt\` only — no new files, no new Gradle dependencies (\`android.hardware\` is part of the framework)
- Sensor callbacks are routed to the main thread via the 4-arg \`registerListener\` overload with \`Handler(Looper.getMainLooper())\`, keeping state writes thread-safe without coroutines

## Known limitation

In landscape orientation the pitch/roll axes are 90° off relative to the screen's visual axes, so the tilt direction will be misaligned in landscape. Portrait (the primary use case) is correct. Can be fixed in a follow-up by reading \`LocalConfiguration.current.orientation\` and swapping the axes.

## Test plan

- [ ] Install on a physical device (sensor unavailable in emulator)
- [ ] Open player screen — artwork is static at rest, fixed in position
- [ ] Tilt phone left/right — artwork rotates subtly on the Y axis
- [ ] Tilt phone forward/backward — artwork rotates subtly on the X axis
- [ ] Artwork does not shift position — only perspective angle changes
- [ ] \`@Preview\` renders normally (sensor = null fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)