### PR TITLE
Add Firestore images collection as artwork fallback

### DIFF
--- a/app/src/main/java/net/afanasev/otonfm/OtonFmApplication.kt
+++ b/app/src/main/java/net/afanasev/otonfm/OtonFmApplication.kt
@@ -1,8 +1,10 @@
 package net.afanasev.otonfm
 
 import android.app.Application
+import net.afanasev.otonfm.data.images.ImagesRepository
 import net.afanasev.otonfm.data.status.StatusRepository
 
 class OtonFmApplication : Application() {
     val statusRepository by lazy { StatusRepository() }
+    val imagesRepository by lazy { ImagesRepository() }
 }

--- a/app/src/main/java/net/afanasev/otonfm/data/images/ImageModel.kt
+++ b/app/src/main/java/net/afanasev/otonfm/data/images/ImageModel.kt
@@ -1,0 +1,6 @@
+package net.afanasev.otonfm.data.images
+
+data class ImageModel(
+    val title: String = "",
+    val url: String = "",
+)

--- a/app/src/main/java/net/afanasev/otonfm/data/images/ImagesRepository.kt
+++ b/app/src/main/java/net/afanasev/otonfm/data/images/ImagesRepository.kt
@@ -1,0 +1,19 @@
+package net.afanasev.otonfm.data.images
+
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.tasks.await
+
+private const val COLLECTION = "images"
+
+class ImagesRepository {
+
+    private val collectionRef = Firebase.firestore.collection(COLLECTION)
+
+    suspend fun getRandomImageUrl(): String? {
+        val snapshot = collectionRef.get().await()
+        if (snapshot.isEmpty) return null
+        val doc = snapshot.documents.random()
+        return doc.toObject(ImageModel::class.java)?.url?.takeIf { it.isNotBlank() }
+    }
+}

--- a/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
+++ b/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
@@ -152,7 +152,8 @@ class PlaybackService : MediaLibraryService() {
                 artworkJob?.cancel()
                 artworkJob = serviceScope.launch {
                     val app = application as OtonFmApplication
-                    val uri = app.imagesRepository.getRandomImageUrl()
+                    val uri = app.statusRepository.fetchArtworkUri(title)
+                        ?: app.imagesRepository.getRandomImageUrl()
                         ?: getString(R.string.default_artwork_uri)
                     val currentItem = player.currentMediaItem ?: return@launch
                     val updatedMetadata = currentItem.mediaMetadata.buildUpon()

--- a/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
+++ b/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
@@ -147,7 +147,9 @@ class PlaybackService : MediaLibraryService() {
 
                 artworkJob?.cancel()
                 artworkJob = serviceScope.launch {
-                    val uri = (application as OtonFmApplication).statusRepository.fetchArtworkUri(title)
+                    val app = application as OtonFmApplication
+                    val uri = app.statusRepository.fetchArtworkUri(title)
+                        ?: app.imagesRepository.getRandomImageUrl()
                         ?: getString(R.string.default_artwork_uri)
                     val currentItem = player.currentMediaItem ?: return@launch
                     val updatedMetadata = currentItem.mediaMetadata.buildUpon()

--- a/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
+++ b/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
@@ -142,11 +142,7 @@ class PlaybackService : MediaLibraryService() {
 
             override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
                 val title = mediaMetadata.title?.toString() ?: return
-                val defaultUri = getString(R.string.default_artwork_uri)
-                val hasCustomArtwork = mediaMetadata.artworkUri?.toString().let {
-                    it != null && it != defaultUri
-                }
-                if (title == lastFetchedTitle && hasCustomArtwork) return
+                if (title == lastFetchedTitle) return
                 lastFetchedTitle = title
 
                 artworkJob?.cancel()

--- a/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
+++ b/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
@@ -141,8 +141,8 @@ class PlaybackService : MediaLibraryService() {
             }
 
             override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
-                val title = mediaMetadata.title?.toString() ?: return
-                if (title == lastFetchedTitle) return
+                val title = mediaMetadata.title?.toString()
+                if (title == null || title == lastFetchedTitle) return
                 lastFetchedTitle = title
 
                 artworkJob?.cancel()

--- a/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
+++ b/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
@@ -141,15 +141,18 @@ class PlaybackService : MediaLibraryService() {
             }
 
             override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
-                val title = mediaMetadata.title?.toString()
-                if (title == null || title == lastFetchedTitle) return
+                val title = mediaMetadata.title?.toString() ?: return
+                val defaultUri = getString(R.string.default_artwork_uri)
+                val hasCustomArtwork = mediaMetadata.artworkUri?.toString().let {
+                    it != null && it != defaultUri
+                }
+                if (title == lastFetchedTitle && hasCustomArtwork) return
                 lastFetchedTitle = title
 
                 artworkJob?.cancel()
                 artworkJob = serviceScope.launch {
                     val app = application as OtonFmApplication
-                    val uri = app.statusRepository.fetchArtworkUri(title)
-                        ?: app.imagesRepository.getRandomImageUrl()
+                    val uri = app.imagesRepository.getRandomImageUrl()
                         ?: getString(R.string.default_artwork_uri)
                     val currentItem = player.currentMediaItem ?: return@launch
                     val updatedMetadata = currentItem.mediaMetadata.buildUpon()


### PR DESCRIPTION
## Summary

- Adds Firestore `images` collection as a fallback artwork source when `statusRepository` returns nothing
- Restores `statusRepository` as the primary artwork lookup (Firestore images are secondary fallback)
- Fixes artwork not refreshing after stop/start with the same track (null `lastFetchedTitle` on `STATE_IDLE`)
- Simplifies `onMediaMetadataChanged`: removes redundant `hasCustomArtwork` check and combines the null/dedup guards into a single return statement

## Test plan

- [ ] Play a track, verify artwork loads from `statusRepository`
- [ ] Play a track with no status artwork, verify Firestore image fallback is used
- [ ] Stop and restart the same track, verify artwork refreshes (no stale cache)
- [ ] Simulate all artwork sources failing, verify no infinite loop / repeated fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)