### PR TITLE
Fix chat layout: inline username with message text

### DIFF
--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/chat/components/MessageRow.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/chat/components/MessageRow.kt
@@ -1,14 +1,17 @@
 package net.afanasev.otonfm.ui.screens.chat.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.PushPin
@@ -19,11 +22,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import net.afanasev.otonfm.R
 import net.afanasev.otonfm.data.chat.MessageModel
 import net.afanasev.otonfm.data.chat.MessageType
 import net.afanasev.otonfm.ui.components.FlagIcon
@@ -68,20 +79,50 @@ fun MessageRow(
 
 @Composable
 private fun UserMessageRow(message: MessageModel, modifier: Modifier = Modifier) {
-    Row(
+    val nameColor = if (message.authorIsAdmin) AdminNameColor else colorForName(message.authorName)
+    val isYakutia = message.authorFlag == "yakutia"
+    val flagKey = "flag"
+
+    val annotated = buildAnnotatedString {
+        if (isYakutia) {
+            appendInlineContent(flagKey, "�")
+        } else {
+            append(message.authorFlag)
+        }
+        append(" ")
+        withStyle(SpanStyle(fontWeight = FontWeight.Bold, color = nameColor)) {
+            append("${message.authorName}:")
+        }
+        append(" ")
+        append(message.text)
+    }
+
+    val inlineContent = if (isYakutia) {
+        mapOf(flagKey to InlineTextContent(
+            placeholder = Placeholder(
+                width = 1.3.em,
+                height = 1.3.em,
+                placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter,
+            )
+        ) {
+            Image(
+                painter = painterResource(R.drawable.flag_yakutia),
+                contentDescription = "Yakutia",
+                modifier = Modifier.fillMaxSize(),
+            )
+        })
+    } else {
+        emptyMap()
+    }
+
+    Text(
+        text = annotated,
+        inlineContent = inlineContent,
+        style = MaterialTheme.typography.bodyMedium,
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp, vertical = 3.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        AuthorHeader(message.authorFlag, message.authorName, message.authorIsAdmin)
-        Spacer(modifier = Modifier.width(6.dp))
-        Text(
-            text = message.text,
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.weight(1f),
-        )
-    }
+    )
 }
 
 @Composable
@@ -192,6 +233,13 @@ private val previewAnnouncement = MessageModel(
     isPinned = true,
 )
 
+private val previewLongMessage = MessageModel(
+    type = MessageType.USER_MESSAGE.value,
+    authorName = "Александр Александров",
+    authorFlag = "🇷🇺",
+    text = "Очень длинное сообщение которое точно не влезет в одну строку и раньше сжималось в узкий правый столбец",
+)
+
 private val previewSystemMessage = MessageModel(
     type = MessageType.SYSTEM.value,
     text = "Иван присоединился к чату",
@@ -204,6 +252,7 @@ private fun MessageRowAllTypesLightPreview() {
         Column {
             MessageRow(previewUserMessage)
             MessageRow(previewAdminMessage)
+            MessageRow(previewLongMessage)
             MessageRow(previewSongRequest)
             MessageRow(previewAnnouncement)
             MessageRow(previewSystemMessage)
@@ -218,6 +267,7 @@ private fun MessageRowAllTypesDarkPreview() {
         Column {
             MessageRow(previewUserMessage)
             MessageRow(previewAdminMessage)
+            MessageRow(previewLongMessage)
             MessageRow(previewSongRequest)
             MessageRow(previewAnnouncement)
             MessageRow(previewSystemMessage)

--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/chat/components/MessageRow.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/chat/components/MessageRow.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.PushPin

--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/ChatButton.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/player/components/ChatButton.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import net.afanasev.otonfm.R
 
 @Composable


### PR DESCRIPTION
## Summary

- Replaces the side-by-side `Row` in `UserMessageRow` (flag + name on the left, message on the right with `weight(1f)`) with a single `Text` composable using `buildAnnotatedString`
- The flag and bold name become an inline prefix, so long names no longer squeeze the message into a narrow right column — everything wraps together naturally
- The custom Yakutia image flag is handled via `InlineTextContent` with `PlaceholderVerticalAlign.TextCenter` to keep it properly centered with the surrounding text baseline
- `SongRequestRow`, `AdminAnnouncementRow`, and `SystemMessageRow` are unchanged

## Test plan

- [ ] Check Android Studio preview panels — the new `previewLongMessage` entry should show the name wrapping inline with the message, not a tall cramped row
- [ ] Verify a regular short message still looks correct
- [ ] Verify admin message name appears in red inline
- [ ] If a Yakutia-flag account is available, confirm the flag image is vertically centered with the text
- [ ] Confirm `SongRequestRow` layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)