### PR TITLE
Add donation support via RevenueCat Paywalls

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -6,6 +8,11 @@ plugins {
     alias(libs.plugins.firebase)
     alias(libs.plugins.crashlytics)
     alias(libs.plugins.sekret)
+}
+
+val localProperties = Properties().apply {
+    val file = rootProject.file("local.properties")
+    if (file.exists()) load(file.inputStream())
 }
 
 android {
@@ -20,6 +27,12 @@ android {
         versionName = "1.7.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField(
+            "String",
+            "REVENUECAT_API_KEY",
+            "\"${localProperties.getProperty("revenuecat.api.key", "")}\""
+        )
     }
 
     buildTypes {
@@ -41,6 +54,7 @@ android {
         jvmTarget = "11"
     }
     buildFeatures {
+        buildConfig = true
         compose = true
     }
 }
@@ -106,4 +120,7 @@ dependencies {
     implementation(libs.google.id.identity)
 
     implementation(libs.sekret.annotation)
+
+    implementation(libs.revenuecat.purchases)
+    implementation(libs.revenuecat.purchases.ui)
 }

--- a/app/src/main/java/net/afanasev/otonfm/MainActivity.kt
+++ b/app/src/main/java/net/afanasev/otonfm/MainActivity.kt
@@ -16,8 +16,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavKey
@@ -31,6 +33,7 @@ import net.afanasev.otonfm.ui.screens.auth.AuthViewModel
 import net.afanasev.otonfm.ui.screens.chat.ChatScreen
 import net.afanasev.otonfm.ui.screens.chat.ChatViewModel
 import net.afanasev.otonfm.ui.screens.contacts.ContactsScreen
+import net.afanasev.otonfm.ui.screens.donation.DonationPaywallDialog
 import net.afanasev.otonfm.ui.screens.menu.MenuScreen
 import net.afanasev.otonfm.ui.screens.player.PlayerViewScreen
 import net.afanasev.otonfm.ui.screens.profilesetup.ProfileSetupScreen
@@ -64,6 +67,7 @@ class MainActivity : ComponentActivity() {
                     val backStack = rememberNavBackStack(MainRoutes.Player)
                     val bottomSheetStrategy = remember { BottomSheetSceneStrategy<NavKey>() }
                     val authViewModel: AuthViewModel = viewModel()
+                    var showDonationPaywall by remember { mutableStateOf(false) }
 
                     NavDisplay(
                         backStack = backStack,
@@ -89,6 +93,10 @@ class MainActivity : ComponentActivity() {
                                     onItemSelected = { route ->
                                         backStack.removeLastOrNull()
                                         backStack.add(route)
+                                    },
+                                    onDonation = {
+                                        backStack.removeLastOrNull()
+                                        showDonationPaywall = true
                                     },
                                     onSignOut = {
                                         authViewModel.signOut()
@@ -146,6 +154,12 @@ class MainActivity : ComponentActivity() {
                                 ChatScreen(chatViewModel, authViewModel)
                             }
                         })
+
+                    if (showDonationPaywall) {
+                        DonationPaywallDialog(
+                            onDismiss = { showDonationPaywall = false },
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/net/afanasev/otonfm/OtonFmApplication.kt
+++ b/app/src/main/java/net/afanasev/otonfm/OtonFmApplication.kt
@@ -1,8 +1,21 @@
 package net.afanasev.otonfm
 
 import android.app.Application
+import com.revenuecat.purchases.LogLevel
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesConfiguration
 import net.afanasev.otonfm.data.status.StatusRepository
 
 class OtonFmApplication : Application() {
+
     val statusRepository by lazy { StatusRepository() }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        Purchases.logLevel = if (BuildConfig.DEBUG) LogLevel.DEBUG else LogLevel.ERROR
+        Purchases.configure(
+            PurchasesConfiguration.Builder(this, BuildConfig.REVENUECAT_API_KEY).build()
+        )
+    }
 }

--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/donation/DonationScreen.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/donation/DonationScreen.kt
@@ -1,0 +1,34 @@
+package net.afanasev.otonfm.ui.screens.donation
+
+import androidx.compose.runtime.Composable
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.ui.revenuecatui.PaywallDialog
+import com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
+import net.afanasev.otonfm.util.log.Logger
+
+@Composable
+fun DonationPaywallDialog(
+    onDismiss: () -> Unit,
+) {
+    PaywallDialog(
+        paywallDialogOptions = PaywallDialogOptions.Builder()
+            .setDismissRequest(onDismiss)
+            .setListener(object : PaywallListener {
+                override fun onPurchaseCompleted(
+                    customerInfo: CustomerInfo,
+                    storeTransaction: StoreTransaction,
+                ) {
+                    Logger.onDonationPurchase(storeTransaction.productIds.firstOrNull() ?: "")
+                    onDismiss()
+                }
+
+                override fun onPurchaseError(error: PurchasesError) {
+                    Logger.onDonationError(error.message)
+                }
+            })
+            .build(),
+    )
+}

--- a/app/src/main/java/net/afanasev/otonfm/ui/screens/menu/MenuScreen.kt
+++ b/app/src/main/java/net/afanasev/otonfm/ui/screens/menu/MenuScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Logout
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.AlternateEmail
+import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -20,6 +21,7 @@ import net.afanasev.otonfm.ui.components.IconTextRowItem
 fun MenuScreen(
     isSignedIn: Boolean,
     onItemSelected: (NavKey) -> Unit,
+    onDonation: () -> Unit,
     onSignOut: () -> Unit,
 ) {
     Column(modifier = Modifier.padding(vertical = 12.dp)) {
@@ -37,6 +39,14 @@ fun MenuScreen(
             onClick = {
                 Logger.onMenuContactsClick()
                 onItemSelected(MainRoutes.Contacts)
+            },
+        )
+        IconTextRowItem(
+            icon = Icons.Outlined.Favorite,
+            stringResId = R.string.menu_donation,
+            onClick = {
+                Logger.onMenuDonationClick()
+                onDonation()
             },
         )
         if (isSignedIn) {

--- a/app/src/main/java/net/afanasev/otonfm/util/log/Logger.kt
+++ b/app/src/main/java/net/afanasev/otonfm/util/log/Logger.kt
@@ -46,6 +46,22 @@ object Logger {
 
     }
 
+    fun onMenuDonationClick() {
+        analytics.logEvent("menu_donation_click", null)
+    }
+
+    fun onDonationPurchase(productId: String) {
+        analytics.logEvent("donation_purchase", Bundle().apply {
+            putString("product_id", productId)
+        })
+    }
+
+    fun onDonationError(message: String) {
+        analytics.logEvent("donation_error", Bundle().apply {
+            putString("msg", message)
+        })
+    }
+
     //endregion
 
     //region Exceptions

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -3,6 +3,7 @@
     <string name="menu_theme">Theme</string>
     <string name="menu_contacts">Contacts</string>
     <string name="menu_sign_out">Log out</string>
+    <string name="menu_donation">Support us</string>
 
     <string name="theme_system">System theme</string>
     <string name="theme_dark">Dark theme</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="menu_theme">Оформление</string>
     <string name="menu_contacts">Контакты</string>
     <string name="menu_sign_out">Выйти</string>
+    <string name="menu_donation">Поддержать</string>
 
     <string name="theme_system">Системная тема</string>
     <string name="theme_dark">Темная тема</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ crashlytics = "3.0.4"
 credentialManager = "1.5.0"
 googleIdIdentity = "1.1.1"
 sekret = "2.3.0"
+revenuecat = "8.20.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -79,6 +80,8 @@ androidx-credentials = { group = "androidx.credentials", name = "credentials", v
 androidx-credentials-play = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentialManager" }
 google-id-identity = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleIdIdentity" }
 sekret-annotation = { group = "net.afanasev", name = "sekret-annotation", version.ref = "sekret" }
+revenuecat-purchases = { group = "com.revenuecat.purchases", name = "purchases", version.ref = "revenuecat" }
+revenuecat-purchases-ui = { group = "com.revenuecat.purchases", name = "purchases-ui", version.ref = "revenuecat" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Integrate RevenueCat SDK (`purchases` + `purchases-ui` 8.20.0) with dashboard-configured paywall for one-time donations
- Add "Support us" / "Поддержать" menu item (heart icon) that opens the RevenueCat PaywallDialog
- Store API key securely via `local.properties` → `BuildConfig` (not committed to git)
- Add Firebase analytics events for donation clicks, purchases, and errors

## Test plan
- [ ] Set `revenuecat.api.key` in `local.properties` and verify build succeeds
- [ ] Open Menu → tap "Support us" → verify paywall dialog appears
- [ ] Configure an offering + paywall in RevenueCat dashboard and verify products display
- [ ] Test purchase flow with a Google Play test account
- [ ] Verify analytics events fire in Firebase debug view

🤖 Generated with [Claude Code](https://claude.com/claude-code)