### PR TITLE
Bump targetSdk to 36 (Android 16)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
     defaultConfig {
         applicationId = "net.afanasev.otonfm"
         minSdk = 29
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 11
         versionName = "1.7.0"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "net.afanasev.otonfm"
         minSdk = 29
         targetSdk = 36
-        versionCode = 11
-        versionName = "1.7.0"
+        versionCode = 12
+        versionName = "1.7.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
+++ b/app/src/main/java/net/afanasev/otonfm/services/PlaybackService.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.media.AudioManager
+import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
@@ -106,7 +107,12 @@ class PlaybackService : MediaLibraryService() {
     override fun onCreate() {
         super.onCreate()
         initMediaSession()
-        registerReceiver(noisyReceiver, IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY))
+        ContextCompat.registerReceiver(
+            this,
+            noisyReceiver,
+            IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {


### PR DESCRIPTION
## Summary
- Move `targetSdk` from 35 to 36 to match the already-bumped `compileSdk` and keep ahead of the upcoming Play Store minimum target requirement.
- Fix `PlaybackService`'s "becoming noisy" broadcast receiver to explicitly declare `RECEIVER_NOT_EXPORTED` via `ContextCompat.registerReceiver`, closing a pre-existing gap (context-registered receivers are required to declare exported state on API 33+; this was still using the bare two-arg overload).

Reviewed the app against the Android 16 behavior changes that come with targeting API 36 — edge-to-edge (already handled via `enableEdgeToEdge()`), large-screen/orientation restrictions (app has no orientation lock or resizability opt-out, so no risk), predictive back (handled via `NavDisplay`'s `onBack`), and 16 KB page size/native libs (no native code in the app or its media3 dependencies). No other code or manifest changes were needed.

## Test plan
- [x] `./gradlew assembleDebug` builds successfully with `targetSdk = 36`
- [ ] Manually verify on an API 36 emulator/device: playback start/stop, headphone unplug stops playback (validates the receiver fix), playback + FCM notifications post correctly, back navigation/predictive-back gesture works
- [ ] Optionally verify resizing/rotation on a large-screen (tablet/foldable) API 36 profile
- [ ] `./gradlew test connectedAndroidTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)